### PR TITLE
Add support for RSA-SHA1 signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,34 @@ differences in how they implement the standard it may be that some APIs
 aren't compatible. If you find an API that it does't work with, open an issue or
 fix the problem yourself and make a pull request against the source code.
 
+### 3-legged OAuth
+
+This library was primarily designed to support the
+[3-legged OAuth flow](http://oauthbible.com/#oauth-10a-three-legged), where
+the end-user visits a web page to grant authorization to your application. The
+"Usage" section above describes how to configure the library for this flow.
+
+### 2-legged OAuth
+
+This library does not currently support the
+[2-legged OAuth flow](http://oauthbible.com/#oauth-10a-two-legged), where
+tokens are generated but the user is not prompted to authorize access.
+
+Be aware that many OAuth providers incorrectly use the term "2-legged" when
+describing their OAuth flow, when in reality they are using the 1-legged flow,
+which this library does support.
+
+### 1-legged OAuth
+
+This library supports the
+[1-legged OAuth flow](http://oauthbible.com/#oauth-10a-one-legged), where the
+consumer key and secret are simply used to sign requests to the API endpoints,
+without the creation or exchanging of tokens. To use this flow, setup the
+service with a consumer key and secret (and optionally a token and token secret)
+and use it to call the API endpoint. See the
+[Semantics3 sample](samples/Semantics3.gs) and [Yelp sample](samples/Yelp.gs)
+for some example usage.
+
 ## Other features
 
 #### Resetting the access token

--- a/samples/XeroPrivate.gs
+++ b/samples/XeroPrivate.gs
@@ -1,0 +1,49 @@
+/**
+ * This sample that demonstrates how to configured the library for the Xero API,
+ * when using a private application. Although the Xero documentation calls it a
+ * "2 legged" flow it is really a 1-legged flow. Public Xero applications use
+ * a 3-legged flow not shown here.
+ * @see {@link https://developer.xero.com/documentation/auth-and-limits/private-applications}
+ */
+
+var CONSUMER_KEY = '...';
+// The private key must be in the PKCS#8 PEM format.
+var PRIVATE_KEY = '-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n';
+
+/**
+ * Authorizes and makes a request to the Xero API.
+ */
+function run() {
+  var service = getService();
+  var url = 'https://api.xero.com/api.xro/2.0/Organisations';
+  var response = service.fetch(url, {
+    headers: {
+      Accept: 'application/json'
+    }
+  });
+  var result = JSON.parse(response.getContentText());
+  Logger.log(JSON.stringify(result, null, 2));
+}
+
+/**
+ * Reset the authorization state, so that it can be re-tested.
+ */
+function reset() {
+  getService().reset();
+}
+
+/**
+ * Configures the service.
+ */
+function getService() {
+  return OAuth1.createService('Xero')
+      // Set the consumer key and secret.
+      .setConsumerKey(CONSUMER_KEY)
+      .setConsumerSecret(PRIVATE_KEY)
+
+      // Manually set the token to be the consumer key.
+      .setAccessToken(CONSUMER_KEY)
+
+      // Set the OAuth signature method.
+      .setSignatureMethod('RSA-SHA1');
+}

--- a/src/Service.gs
+++ b/src/Service.gs
@@ -104,7 +104,7 @@ Service_.prototype.setMethod = function(method) {
 /**
  * Sets the OAuth signature method to use. 'HMAC-SHA1' is the default.
  * @param {string} signatureMethod The OAuth signature method. Allowed values
- *     are 'HMAC-SHA1' and 'PLAINTEXT'.
+ *     are 'HMAC-SHA1', 'RSA-SHA1' and 'PLAINTEXT'.
  * @return {Service_} This service, for chaining.
  */
 Service_.prototype.setSignatureMethod = function(signatureMethod) {

--- a/src/Signer.gs
+++ b/src/Signer.gs
@@ -69,7 +69,11 @@
         };
         break;
       case 'RSA-SHA1':
-        throw new Error('oauth-1.0a does not support this signature method right now. Coming Soon...');
+        this.hash = function(base_string, key) {
+          var sig = Utilities.computeRsaSignature(Utilities.RsaAlgorithm.RSA_SHA_1, base_string, key);
+          return Utilities.base64Encode(sig);
+        }
+        break;
       default:
         throw new Error('The OAuth 1.0a protocol defines three signature methods: HMAC-SHA1, RSA-SHA1, and PLAINTEXT only');
     }
@@ -169,6 +173,13 @@
   */
   OAuth.prototype.getSigningKey = function(token_secret) {
     token_secret = token_secret || '';
+
+    // Don't percent encode the signing key (PKCS#8 PEM private key) when using
+    // the RSA-SHA1 method. The token secret is never used with the RSA-SHA1
+    // method.
+    if (this.signature_method === 'RSA-SHA1') {
+      return this.consumer.secret;
+    }
 
     if(!this.last_ampersand && !token_secret) {
       return this.percentEncode(this.consumer.secret);


### PR DESCRIPTION
Now that RSA-SHA1 signing is possible in Apps Script, add support to the library. Add a sample for the Xero API which uses RSA-SHA1. Also clarify in the readme the support for the different OAuth flows supported.

Fixes #30.