### PR TITLE
Add Jira sample and better error handling

### DIFF
--- a/samples/Jira.gs
+++ b/samples/Jira.gs
@@ -1,0 +1,78 @@
+/**
+ * This sample demonstrates how to configure the library for the Jira REST API.
+ * @see {@link https://developer.atlassian.com/cloud/jira/platform/jira-rest-api-oauth-authentication/}
+ */
+
+var SITE = 'https://something.atlassian.net';
+var CONSUMER_KEY = '...';
+// The private key must be in the PKCS#8 PEM format.
+var PRIVATE_KEY = '-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n';
+
+/**
+ * Authorizes and makes a request to the Xero API.
+ */
+function run() {
+  var service = getService();
+  if (service.hasAccess()) {
+    var url = SITE + '/rest/api/3/myself';
+    var response = service.fetch(url, {
+      headers: {
+        Accept: 'application/json'
+      }
+    });
+    var result = JSON.parse(response.getContentText());
+    Logger.log(JSON.stringify(result, null, 2));
+  } else {
+    var authorizationUrl = service.authorize();
+    Logger.log('Open the following URL and re-run the script: %s',
+        authorizationUrl);
+  }
+}
+
+/**
+ * Reset the authorization state, so that it can be re-tested.
+ */
+function reset() {
+  getService().reset();
+}
+
+/**
+ * Configures the service.
+ */
+function getService() {
+  return OAuth1.createService('Jira')
+      // Set the endpoint URLs.
+      .setRequestTokenUrl(SITE + '/plugins/servlet/oauth/request-token')
+      .setAuthorizationUrl(SITE + '/plugins/servlet/oauth/authorize')
+      .setAccessTokenUrl(SITE + '/plugins/servlet/oauth/access-token')
+
+      // Set the consumer key and secret.
+      .setConsumerKey(CONSUMER_KEY)
+      .setConsumerSecret(PRIVATE_KEY)
+
+      // Set the OAuth signature method.
+      .setSignatureMethod('RSA-SHA1')
+
+      // Set the method to POST, as required by Atlassian.
+      .setMethod('post')
+
+      // Set the name of the callback function in the script referenced
+      // above that should be invoked to complete the OAuth flow.
+      .setCallbackFunction('authCallback')
+
+      // Set the property store where authorized tokens should be persisted.
+      .setPropertyStore(PropertiesService.getUserProperties());
+}
+
+/**
+ * Handles the OAuth callback.
+ */
+function authCallback(request) {
+  var service = getService();
+  var authorized = service.handleCallback(request);
+  if (authorized) {
+    return HtmlService.createHtmlOutput('Success!');
+  } else {
+    return HtmlService.createHtmlOutput('Denied');
+  }
+}

--- a/samples/XeroPrivate.gs
+++ b/samples/XeroPrivate.gs
@@ -1,6 +1,6 @@
 /**
- * This sample that demonstrates how to configured the library for the Xero API,
- * when using a private application. Although the Xero documentation calls it a
+ * This sample demonstrates how to configure the library for the Xero API, when
+ * using a private application. Although the Xero documentation calls it a
  * "2 legged" flow it is really a 1-legged flow. Public Xero applications use
  * a 3-legged flow not shown here.
  * @see {@link https://developer.xero.com/documentation/auth-and-limits/private-applications}

--- a/samples/XeroPrivate.gs
+++ b/samples/XeroPrivate.gs
@@ -1,5 +1,5 @@
 /**
- * This sample demonstrates how to configure the library for the Xero API, when
+ * This sample demonstrates how to configure the library for the Xero API when
  * using a private application. Although the Xero documentation calls it a
  * "2 legged" flow it is really a 1-legged flow. Public Xero applications use
  * a 3-legged flow not shown here.

--- a/src/Service.gs
+++ b/src/Service.gs
@@ -455,6 +455,10 @@ Service_.prototype.parseToken_ = function(content) {
     result[decodeURIComponent(parts[0])] = decodeURIComponent(parts[1]);
     return result;
   }, {});
+  // Verify that the response contains a token.
+  if (!token.oauth_token) {
+    throw 'Error parsing token: key "oauth_token" not found';
+  }
   // Set fields that the signing library expects.
   token.public = token.oauth_token;
   token.secret = token.oauth_token_secret;


### PR DESCRIPTION
The Jira OAuth endpoints don't return an error if you use the unsupported `GET` method, and instead just return a 200 response with no token. Added some code to detect a missing token in the response and throw an error. Fixes #35.