### PR TITLE
Add OAuth1 realm parameter.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apps-script-oauth1",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "OAuth1 for Apps Script is a library for Google Apps Script that provides the ability to create and authorize OAuth1 tokens. ",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apps-script-oauth1",
-  "version": "1.16.0",
+  "version": "1.15.0",
   "description": "OAuth1 for Apps Script is a library for Google Apps Script that provides the ability to create and authorize OAuth1 tokens. ",
   "repository": {
     "type": "git",

--- a/src/Service.gs
+++ b/src/Service.gs
@@ -102,6 +102,16 @@ Service_.prototype.setMethod = function(method) {
 };
 
 /**
+ * Sets the OAuth realm parameter to be used with this service (optional).
+ * @param {string} realm The realm to be used with this service.
+ * @return {Service_} This service, for chaining.
+ */
+Service_.prototype.setRealm = function(realm) {
+  this.realm_ = realm;
+  return this;
+};
+
+/**
  * Sets the OAuth signature method to use. 'HMAC-SHA1' is the default.
  * @param {string} signatureMethod The OAuth signature method. Allowed values
  *     are 'HMAC-SHA1', 'RSA-SHA1' and 'PLAINTEXT'.
@@ -415,6 +425,9 @@ Service_.prototype.fetchInternal_ = function(url, params, opt_token,
     request.data = data;
   }
   oauthParams = signer.authorize(request, token, oauthParams);
+  if (this.realm_ != null) {
+    oauthParams.realm = this.realm_;
+  }
   switch (this.paramLocation_) {
     case 'auth-header':
       params.headers = _.extend({}, params.headers,

--- a/src/Signer.gs
+++ b/src/Signer.gs
@@ -24,6 +24,7 @@
  * https://github.com/ddo/oauth-1.0a
  * The cryptojs dependency was removed in favor of native Apps Script functions.
  * A new parameter was added to authorize() for additional oauth params.
+ * Support for realm authorization parameter was added in toHeader().
  */
 
 (function(global) {

--- a/src/Signer.gs
+++ b/src/Signer.gs
@@ -267,7 +267,7 @@
     var header_value = 'OAuth ';
 
     for(var key in oauth_data) {
-      if (key.indexOf('oauth_') === -1)
+      if (key !== 'realm' && key.indexOf('oauth_') === -1)
         continue;
       header_value += this.percentEncode(key) + '="' + this.percentEncode(oauth_data[key]) + '"' + this.parameter_seperator;
     }


### PR DESCRIPTION
Adds an option to send a `realm="..."` parameter in the Authentication header, for example:

```
function getService() {
    return OAuth1.createService("NetSuite")
        .setRealm('1234567_SB1')
        .setConsumerKey(CONSUMER_KEY)
        .setConsumerSecret(CONSUMER_SECRET)
        .setAccessToken(TOKEN, TOKEN_SECRET);
}
```